### PR TITLE
Fix migration of boolean attributes

### DIFF
--- a/src/Profile/Magento/Converter/MagentoConverter.php
+++ b/src/Profile/Magento/Converter/MagentoConverter.php
@@ -94,7 +94,12 @@ abstract class MagentoConverter extends Converter
             if (in_array($attribute['attribute_code'], $blacklist, true)) {
                 continue;
             }
-            $result['migration_' . $connectionName . '_' . $entityName . '_' . $attribute['attribute_id']] = $attribute['value'];
+
+            $value = $attribute['value'];
+            if (isset($attribute['frontend_input']) && $attribute['frontend_input'] == 'boolean') {
+                $value = (bool)$value;
+            }
+            $result['migration_' . $connectionName . '_' . $entityName . '_' . $attribute['attribute_id']] = $value;
         }
 
         return $result;

--- a/src/Profile/Magento/Gateway/Local/Reader/ProductReader.php
+++ b/src/Profile/Magento/Gateway/Local/Reader/ProductReader.php
@@ -150,6 +150,7 @@ SELECT
     product.entity_id,
     attribute.attribute_id,
     attribute.attribute_code,
+       attribute.frontend_input,
     CASE attribute.backend_type
        WHEN 'varchar' THEN product_varchar.value
        WHEN 'int' THEN product_int.value


### PR DESCRIPTION
### 1. Why is this change necessary?
During the migration following error is thrown: "This value should be of type bool." After some searching I found out, that its converting the values that come from Magento are all converted to string values. But if there is a boolean field it is throwing the error above.

### 2. What does this change do, exactly?
In this change the frontend_input will be added to the database query. In the converter is a check for the frontend_input. If its a boolean attribute the value gets casted as bool.

### 3. Describe each step to reproduce the issue or behaviour.
* Create an attribute in Magento with frontend_input = boolean
* Create a product and set the created attribute
* Start the migration tool

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.