### PR TITLE
Query fix for CategoryReader

### DIFF
--- a/src/Profile/Magento/Gateway/Local/Reader/CategoryReader.php
+++ b/src/Profile/Magento/Gateway/Local/Reader/CategoryReader.php
@@ -51,7 +51,7 @@ LEFT JOIN {$this->tablePrefix}catalog_category_entity_varchar as name
     AND name.attribute_id = (SELECT attribute.attribute_id FROM {$this->tablePrefix}eav_attribute attribute WHERE attribute.`entity_type_id` = category.`entity_type_id` AND attribute.attribute_code = 'name')
     AND name.store_id = 0
         
-LEFT JOIN {$this->tablePrefix}catalog_category_entity_int status 
+LEFT JOIN {$this->tablePrefix}catalog_category_entity_int AS status 
     ON category.entity_id = status.entity_id
     AND status.attribute_id = (SELECT attribute.attribute_id FROM {$this->tablePrefix}eav_attribute attribute WHERE attribute.`entity_type_id` = category.`entity_type_id` AND attribute.attribute_code = 'is_active')
     AND status.store_id = 0


### PR DESCRIPTION
 ### 1. Why is this change necessary?
Otherwise migrating categories will fail and throw an error in the `swag_migration_logging` table.

 ### 2. What does this change do, exactly?
Fix the JOIN clause for `catalog_category_entity_int`.

 ### 3. Describe each step to reproduce the issue or behaviour.
Run the the Migration Assistant and migrate categories.

### 4. Please link to the relevant issues (if any).
### 5. Checklist
* [x]  I have written tests and verified that they fail without my change
* [x]  I have squashed any insignificant commits
 * [ ]  I have written or adjusted the documentation according to my changes
 * [ ]  This change has comments for package types, values, functions, and non-obvious lines of code
 * [x]  I have read the contribution requirements and fulfil them.