### PR TITLE
Category Order by parent_id rather than level

### DIFF
--- a/src/Profile/Magento/Gateway/Local/Reader/CategoryReader.php
+++ b/src/Profile/Magento/Gateway/Local/Reader/CategoryReader.php
@@ -140,7 +140,7 @@ LEFT JOIN {$this->tablePrefix}catalog_category_entity AS sibling
                     LIMIT 1)
 WHERE category.entity_id IN (?)
 
-ORDER BY level, position;
+ORDER BY parent_id, position;
 SQL;
 
         return $this->connection->executeQuery(


### PR DESCRIPTION
There is some issues I found with the reliability of the column "level" in Magento 1.9.4

After doing a test import I got a lot of errors for "Entity: category, sourceId: -
Parent entity for "category: 47" child not found." for categories and then products for those categories didn't import.

The issue is that the column level for some categories was the same for the parent and child category and if the child category was imported first you got this error.

So instead, I have ordered by the parent_id so the child category is imported after the parent to avoid this error.

