### PR TITLE
Fix undefined index for media with no label

### DIFF
--- a/src/Profile/Magento/Converter/ProductConverter.php
+++ b/src/Profile/Magento/Converter/ProductConverter.php
@@ -761,7 +761,7 @@ class ProductConverter extends MagentoConverter
             $newMedia['id'] = $mapping['entityUuid'];
             $this->mappingIds[] = $mapping['id'];
 
-            if (!isset($mediaData['description'])) {
+            if (!isset($mediaData['description']) || empty($mediaData['description'])) {
                 $mediaData['description'] = $newMedia['id'];
 
                 $fileMatches = [];


### PR DESCRIPTION
I'm getting a notice warning during migration of products because `catalog_product_entity_media_gallery_value.label` has empty string and null values.