### PR TITLE
Update LocalMediaProcessor.php

### DIFF
--- a/src/Profile/Magento/Media/LocalMediaProcessor.php
+++ b/src/Profile/Magento/Media/LocalMediaProcessor.php
@@ -246,7 +246,7 @@ class LocalMediaProcessor extends BaseMediaService implements MediaFileProcessor
                 $fileSize = filesize($filePath);
                 $mappedWorkload[$mediaId]->setState(MediaProcessWorkloadStruct::FINISH_STATE);
 
-                $this->persistFileToMedia($filePath, $mediaId, $mediaFile['file_name'], $fileSize, $fileExtension, $context);
+                $this->persistFileToMedia($filePath, $mediaId, urlencode($mediaFile['file_name']), $fileSize, $fileExtension, $context);
                 unlink($filePath);
             } else {
                 $mappedWorkload[$mediaId]->setState(MediaProcessWorkloadStruct::ERROR_STATE);


### PR DESCRIPTION
If the media files contain special characters or german umlauts, it may lead to problems storing the files in the file system. Example: file "groß.jpg" will be stored as "gro??.jpg" and subsequently the Thumbnail process will fail. The quickfix is to simply urlencode the filename. I also would suggest not to take the image description from magento as default file_name, why not take the original file name?