### PR TITLE
Update LocalMediaProcessor.php

### DIFF
--- a/src/Profile/Magento/Media/LocalMediaProcessor.php
+++ b/src/Profile/Magento/Media/LocalMediaProcessor.php
@@ -277,7 +277,9 @@ class LocalMediaProcessor extends BaseMediaService implements MediaFileProcessor
         $context->disableCache(function (Context $context) use ($mediaId, $filePath, $fileName, $fileSize, $fileExtension): void {
             $mimeType = mime_content_type($filePath);
             $mediaFile = new MediaFile($filePath, $mimeType, $fileExtension, $fileSize);
-
+            
+            $fileName =  preg_replace('/[^a-zA-Z0-9_-]+/', '-', strtolower($fileName));
+            
             try {
                 $this->fileSaver->persistFileToMedia($mediaFile, $fileName, $mediaId, $context);
             } catch (DuplicatedMediaFileNameException $e) {


### PR DESCRIPTION
Filenames like "Shopzubehör groß.jpg", which are generated from the Magento description (and not the filename) are leading to problems with saving in the file system and thumbnail generation. I could not import the media from a Magento 1.9. The fix 
cleans up the filename (the regex is far from perfect, but it works for now) -  this fixed all issues for me and i could successfully import all images from my magento install (2400 images) and all thumbnails were created successfully