### PR TITLE
Use website locale as fallback for languages.

### DIFF
--- a/src/Profile/Magento/Gateway/Local/Reader/LanguageReader.php
+++ b/src/Profile/Magento/Gateway/Local/Reader/LanguageReader.php
@@ -30,6 +30,12 @@ abstract class LanguageReader extends AbstractReader
             'localeconfig',
             'localeconfig.scope = \'stores\' AND localeconfig.path = \'general/locale/code\' AND store.store_id = localeconfig.scope_id'
         );
+        $query->leftJoin(
+            'store',
+            $this->tablePrefix . 'core_config_data',
+            'websitelocale',
+            'websitelocale.scope = \'websites\' AND websitelocale.path = \'general/locale/code\' AND store.website_id = websitelocale.scope_id'
+        );
         $query->innerJoin(
             'store',
             $this->tablePrefix . 'core_config_data',
@@ -38,6 +44,7 @@ abstract class LanguageReader extends AbstractReader
         );
         $query->addSelect('store.store_id');
         $query->addSelect('localeconfig.value as locale');
+        $query->addSelect('websitelocale.value as websiteLocale');
         $query->addSelect('defaultlocale.value as defaultLocale');
 
         $query = $query->execute();
@@ -49,7 +56,11 @@ abstract class LanguageReader extends AbstractReader
         $storeConfigs = [];
         foreach ($configurations as $storeConfig) {
             if ($storeConfig['locale'] === null) {
-                $storeConfig['locale'] = $storeConfig['defaultLocale'];
+                if($storeConfig['websiteLocale'] !== null) {
+                    $storeConfig['locale'] = $storeConfig['websiteLocale'];
+                } else {
+                    $storeConfig['locale'] = $storeConfig['defaultLocale'];
+                }
             }
             if (isset($storeConfigs[$storeConfig['locale']])) {
                 $storeConfigs[$storeConfig['locale']]['stores'][] = $storeConfig['store_id'];


### PR DESCRIPTION
Magento has a multi-layer inheritance for the configuration going from default (global) to websites to store views. Languages were only fetched via default and store views. This PR fixes that by adding websites as an intermediate fallback.