### PR TITLE
[FIX] fix error when shipping method name is empty

### DIFF
--- a/src/Profile/Magento/Premapping/ShippingMethodReader.php
+++ b/src/Profile/Magento/Premapping/ShippingMethodReader.php
@@ -87,7 +87,7 @@ abstract class ShippingMethodReader extends AbstractPremappingReader
                 $uuid = $this->connectionPremappingDictionary[$data['carrier_id']]['destinationUuid'];
             }
 
-            $entityData[] = new PremappingEntityStruct($data['carrier_id'], $data['value'], $uuid);
+            $entityData[] = new PremappingEntityStruct($data['carrier_id'], $data['value'] ?? 'unknown', $uuid);
         }
 
         $uuid = '';


### PR DESCRIPTION
I'm not realy sure why this happens, but I already had two migrations of different shops that had an empty `$data['value']` for some shipping methods. This fixes this, but probably could be improved by naming it something more specific than 'unknown'.