### PR TITLE
bugfix, not all property group options are migrated

### DIFF
--- a/src/Profile/Magento/Gateway/Local/Reader/PropertyGroupReader.php
+++ b/src/Profile/Magento/Gateway/Local/Reader/PropertyGroupReader.php
@@ -45,7 +45,7 @@ abstract class PropertyGroupReader extends AbstractReader
             foreach ($fetchedOptions[$groupId] as $option) {
                 $optionId = $option['optionId'];
 
-                if (!isset($optionIds[$optionId])) {
+                if (!in_array($optionId, $optionIds)) {
                     $optionIds[] = $optionId;
                 }
 


### PR DESCRIPTION
not all property group options are migrated, because the fetched options does not get all option ids.