### PR TITLE
ci: pin migration assistant version

### DIFF
--- a/.github/actions/setup-magento-plugin/action.yml
+++ b/.github/actions/setup-magento-plugin/action.yml
@@ -56,3 +56,9 @@ runs:
               "branch": "${{ inputs.migration-assistant-ref }}"
             }
           ]
+
+    - name: Fetch SwagMigrationAssistant tests for PHPStan
+      shell: bash
+      run: |
+        git -C custom/plugins/SwagMigrationAssistant fetch origin trunk
+        git -C custom/plugins/SwagMigrationAssistant checkout origin/trunk -- tests/

--- a/.github/actions/setup-magento-plugin/action.yml
+++ b/.github/actions/setup-magento-plugin/action.yml
@@ -18,6 +18,10 @@ inputs:
     default: "trunk"
     required: false
     description: "Which Shopware version should be used"
+  migration-assistant-ref:
+    default: "16.2.0"
+    required: false
+    description: "Which SwagMigrationAssistant ref should be used"
 
 runs:
   using: composite
@@ -48,6 +52,7 @@ runs:
           [
             {
               "name": "SwagMigrationAssistant",
-              "repo": "https://github.com/shopware/SwagMigrationAssistant.git"
+              "repo": "https://github.com/shopware/SwagMigrationAssistant.git",
+              "branch": "${{ inputs.migration-assistant-ref }}"
             }
           ]

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "shopware/core": "~6.7",
-        "swag/migration-assistant": "~16.1"
+        "swag/migration-assistant": "16.2.0"
     },
     "extra": {
         "shopware-plugin-class": "Swag\\MigrationMagento\\SwagMigrationMagento",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -15,7 +15,6 @@ parameters:
 
     scanDirectories:
         - ../SwagMigrationAssistant/src
-        - ../SwagMigrationAssistant/tests
 
     symfony:
         constantHassers: false
@@ -45,4 +44,3 @@ parameters:
 
         # TODO: https://github.com/shopware/shopware/issues/16034
         - identifier: empty.notAllowed
-

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -15,6 +15,7 @@ parameters:
 
     scanDirectories:
         - ../SwagMigrationAssistant/src
+        - ../SwagMigrationAssistant/tests
 
     symfony:
         constantHassers: false
@@ -44,3 +45,4 @@ parameters:
 
         # TODO: https://github.com/shopware/shopware/issues/16034
         - identifier: empty.notAllowed
+


### PR DESCRIPTION
nightly was failing cause of incompatibility with unreleased SwagMigrationAssistant changes in trunk.
ref to failing run: https://github.com/shopware/SwagMigrationMagento/actions/runs/24431744155

### Changes

- pinned the version of migration assistant in ci