### PR TITLE
fix: phpunit bootstrap plugin install order

### DIFF
--- a/tests/TestBootstrap.php
+++ b/tests/TestBootstrap.php
@@ -17,10 +17,20 @@ if (is_readable(__DIR__ . '/../vendor/shopware/platform/src/Core/TestBootstrappe
     exit('Could not find TestBootstrapper.php');
 }
 
-return (new TestBootstrapper())
-    ->setProjectDir($_SERVER['PROJECT_ROOT'] ?? dirname(__DIR__, 4))
+$projectDir = $_SERVER['PROJECT_ROOT'] ?? dirname(__DIR__, 4);
+
+// Install dependency first: calling plugins install hook needs Assistant schema
+(new TestBootstrapper())
+    ->setProjectDir($projectDir)
     ->setLoadEnvFile(true)
-    ->addActivePlugins('SwagMigrationAssistant', 'SwagMigrationMagento')
+    ->addActivePlugins('SwagMigrationAssistant')
+    ->bootstrap();
+
+return (new TestBootstrapper())
+    ->setProjectDir($projectDir)
+    ->setLoadEnvFile(true)
+    ->setForceInstall(false)
+    ->setForceInstallPlugins(true)
     ->addCallingPlugin()
     ->bootstrap()
     ->setClassLoader(require dirname(__DIR__) . '/vendor/autoload.php')


### PR DESCRIPTION
Fixes nightly phpunit bootstrap failing cause of changes in platform [shopware/shopware#16674](https://github.com/shopware/shopware/pull/16674)

Shopware changed `TestBootstrapper::installPlugins()` to install all active plugins in a single `plugin:install` call. With both `SwagMigrationAssistant` and `SwagMigrationMagento` passed together, the lifecycle command falls back to fuzzy matching, finds both `SwagMigration*` plugins, and prompts for interactive input during phpunit.

This installs the assistant first and then force-installs the calling plugin separately, keeping both plugin install calls exact.