### PR TITLE
ci: add compat check

### DIFF
--- a/.github/actions/setup-magento-plugin/action.yml
+++ b/.github/actions/setup-magento-plugin/action.yml
@@ -21,7 +21,7 @@ inputs:
   assistant-branch:
     default: ""
     required: false
-    description: "Which SwagMigrationAssistant branch to use. Defaults to the latest release (release/<version>)."
+    description: "Which SwagMigrationAssistant branch to use. Defaults to the highest release tag matching the composer.json constraint (release/<version>)."
 
 runs:
   using: composite
@@ -29,12 +29,34 @@ runs:
     - name: Resolve SwagMigrationAssistant branch
       shell: bash
       run: |
+        set -euo pipefail
+
         if [ -n "${{ inputs.assistant-branch }}" ]; then
           echo "ASSISTANT_BRANCH=${{ inputs.assistant-branch }}" >> $GITHUB_ENV
-        else
-          VERSION=$(gh api repos/shopware/SwagMigrationAssistant/releases/latest --jq '.tag_name')
-          echo "ASSISTANT_BRANCH=release/${VERSION}" >> $GITHUB_ENV
+          exit 0
         fi
+
+        COMPOSER_JSON="${GITHUB_ACTION_PATH}/../../../composer.json"
+        CONSTRAINT=$(jq -r '.require["swag/migration-assistant"]' "$COMPOSER_JSON")
+        MAJOR=$(echo "$CONSTRAINT" | grep -oE '[0-9]+' | head -1)
+
+        if [ -z "$MAJOR" ]; then
+          echo "Failed to parse major version from constraint: $CONSTRAINT" >&2
+          exit 1
+        fi
+
+        VERSION=$(gh api --paginate repos/shopware/SwagMigrationAssistant/releases --jq '.[].tag_name' \
+          | grep -E "^v?${MAJOR}\." \
+          | sort -V \
+          | tail -1)
+
+        if [ -z "$VERSION" ]; then
+          echo "No SwagMigrationAssistant release tag found matching major ${MAJOR} (constraint: ${CONSTRAINT})" >&2
+          exit 1
+        fi
+
+        echo "Resolved SwagMigrationAssistant ${VERSION} for constraint ${CONSTRAINT}"
+        echo "ASSISTANT_BRANCH=release/${VERSION}" >> $GITHUB_ENV
       env:
         GH_TOKEN: ${{ github.token }}
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+    - package-ecosystem: 'github-actions'
+      directory: '/'
+      schedule:
+          interval: 'weekly'
+      reviewers:
+          - 'shopware/product-cc-after-sales'
+      commit-message:
+          prefix: 'chore'
+      groups:
+          github-actions:
+              patterns:
+                  - '*'

--- a/.github/workflows/action-phpstan.yml
+++ b/.github/workflows/action-phpstan.yml
@@ -10,6 +10,10 @@ on:
         required: false
         type: string
         default: trunk
+      assistant_branch:
+        required: false
+        type: string
+        default: ""
 
 jobs:
   phpstan:
@@ -17,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout SwagMigrationMagento
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: custom/plugins/${{ inputs.extension_name }}
 
@@ -25,6 +29,7 @@ jobs:
         uses: ./custom/plugins/SwagMigrationMagento/.github/actions/setup-magento-plugin
         with:
           platform-branch: ${{ inputs.platform_branch }}
+          assistant-branch: ${{ inputs.assistant_branch }}
 
       - name: Run PHPStan
         run: |

--- a/.github/workflows/action-phpunit.yml
+++ b/.github/workflows/action-phpunit.yml
@@ -10,6 +10,10 @@ on:
         required: false
         type: string
         default: trunk
+      assistant_branch:
+        required: false
+        type: string
+        default: ""
 
 jobs:
   phpunit:
@@ -22,7 +26,7 @@ jobs:
         php_version: ["8.2", "8.3"]
     steps:
       - name: Checkout SwagMigrationMagento
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: custom/plugins/${{ inputs.extension_name }}
 
@@ -32,6 +36,7 @@ jobs:
           php-version: ${{ matrix.php_version }}
           mysql-version: ${{ matrix.mysql_image }}
           platform-branch: ${{ inputs.platform_branch }}
+          assistant-branch: ${{ inputs.assistant_branch }}
 
       - name: Run PHPUnit
         working-directory: custom/plugins/${{ inputs.extension_name }}

--- a/.github/workflows/compat-check.yml
+++ b/.github/workflows/compat-check.yml
@@ -1,0 +1,113 @@
+name: Compat Check
+
+on:
+  schedule:
+    - cron: '0 1 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: compat-check-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  resolve:
+    name: Resolve latest SwagMigrationAssistant release
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.latest.outputs.version }}
+    steps:
+      - name: Resolve latest release tag
+        id: latest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          VERSION=$(gh api repos/shopware/SwagMigrationAssistant/releases/latest --jq '.tag_name')
+
+          if [ -z "$VERSION" ]; then
+            echo "Failed to resolve latest SwagMigrationAssistant release tag" >&2
+            exit 1
+          fi
+
+          echo "Latest SwagMigrationAssistant release: ${VERSION}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+  phpstan:
+    name: PHPStan
+    needs: resolve
+    uses: ./.github/workflows/action-phpstan.yml
+    with:
+      extension_name: ${{ github.event.repository.name }}
+      platform_branch: trunk
+      assistant_branch: release/${{ needs.resolve.outputs.version }}
+
+  phpunit:
+    name: PHPUnit
+    needs: resolve
+    uses: ./.github/workflows/action-phpunit.yml
+    with:
+      extension_name: ${{ github.event.repository.name }}
+      platform_branch: trunk
+      assistant_branch: release/${{ needs.resolve.outputs.version }}
+
+  notify_once:
+    name: Slack Notify
+    runs-on: ubuntu-latest
+    needs:
+      - resolve
+      - phpstan
+      - phpunit
+    if: >-
+      always() &&
+      github.event_name == 'schedule' &&
+      needs.resolve.result == 'success' &&
+      (
+        needs.phpstan.result == 'failure' ||
+        needs.phpunit.result == 'failure'
+      )
+    steps:
+      - name: Dedup cache lookup
+        id: dedup
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .compat-notified
+          key: compat-alert-${{ needs.resolve.outputs.version }}
+          lookup-only: true
+
+      - name: Notify Slack
+        if: steps.dedup.outputs.cache-hit != 'true'
+        env:
+          SLACK_COMPAT_WEBHOOK_URL: ${{ secrets.SLACK_COMPAT_WEBHOOK_URL }}
+          REPOSITORY: ${{ github.repository }}
+          DEPENDENCY: SwagMigrationAssistant
+          VERSION: ${{ needs.resolve.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          payload=$(
+            jq -nc \
+              --arg repository "$REPOSITORY" \
+              --arg dependency "$DEPENDENCY" \
+              --arg version "$VERSION" \
+              '{
+                repository: $repository,
+                dependency: $dependency,
+                version: $version
+              }'
+          )
+
+          curl -fsSL -X POST \
+            -H 'Content-type: application/json' \
+            --data "$payload" \
+            "$SLACK_COMPAT_WEBHOOK_URL"
+
+          mkdir -p .compat-notified
+          echo "$VERSION" > .compat-notified/version
+
+      - name: Persist dedup marker
+        if: steps.dedup.outputs.cache-hit != 'true'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .compat-notified
+          key: compat-alert-${{ needs.resolve.outputs.version }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run Danger PHP
         uses: docker://ghcr.io/shyim/danger-php:latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 13.0.0
+
+- Compatibility with Migration Assistant version 18.
+- Increased the minimum required Migration Assistant version to ~18.0.
+
 # 12.0.0
 
 - Compatibility with Migration Assistant version 17.

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,8 @@
+# 13.0.0
+
+- Kompatibilität mit Migration Assistant Version 18.
+- Mindestanforderung des Migration Assistant auf ~18.0 erhöht.
+
 # 12.0.0
 
 - Kompatibilität mit Migration Assistant Version 17.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,7 @@
+# 13.0.0
+
+- [BREAKING] Raised required `swag/migration-assistant` version from `~17.0` to `~18.0`.
+
 # 12.0.0
 
 - [BREAKING] Raised required `swag/migration-assistant` version from `~16.2` to `~17.0`.

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "swag/migration-magento",
     "description": "Magento profiles for Shopware Migration Assistant",
-    "version": "12.0.0",
+    "version": "13.0.0",
     "type": "shopware-platform-plugin",
     "license": "MIT",
     "authors": [
@@ -11,7 +11,7 @@
     ],
     "require": {
         "shopware/core": "~6.7",
-        "swag/migration-assistant": "~17.0"
+        "swag/migration-assistant": "~18.0"
     },
     "extra": {
         "shopware-plugin-class": "Swag\\MigrationMagento\\SwagMigrationMagento",

--- a/src/Resources/app/administration/src/init/translation.init.ts
+++ b/src/Resources/app/administration/src/init/translation.init.ts
@@ -1,5 +1,5 @@
 /**
- * @deprecated tag:v13.0.0 - With Shopware v6.8.0 - `translation.init.ts` will be removed to use automatic language loading with language layer support
+ * @deprecated tag:v14.0.0 - With Shopware v6.8.0 - `translation.init.ts` will be removed to use automatic language loading with language layer support
  */
 import deMagentoSnippets from '../app/snippet/de.json';
 import enMagentoSnippets from '../app/snippet/en.json';


### PR DESCRIPTION
Bumps the plugin to track Assistant ~18.0 (v13.0.0) and adds a nightly workflow that runs the test suite against the latest upstream release so we hear about breakage before users do decoupled from normal nightly

### Changes

- version bump: assistant ~17.0 -> ~18.0, magento 12.0.0 -> 13.0.0
- pin action versions and add dependabot
- new compat-check.yml

#### Why new compat check?

  | Workflow | Tests against | Purpose | Failure means |
  |---|---|---|---|
  | **Nightly** | The Assistant major declared in `composer.json` | Regression gate for currently-supported version | Real bug |
  | **Compat Check** | The latest Assistant release (`releases/latest`) | Early warning for new majors | Expected, we haven't bumped yet |

Decoupling lets each have the right noise profile:
- Nightly fails loudly and pages on every failure = every failure is a real regression now.
- compat check fails quietly: one Slack alert per new Assistant version, then silent until the next one drops.